### PR TITLE
Suppress warnings of Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "devise"
 gem "devise-encryptable"
 
 group :development do
-  gem "sqlite3"
   gem "thin"
 
   gem "debugger"
@@ -21,11 +20,14 @@ group :development do
 end
 
 group :test do
-  gem "sqlite3"
   gem "test-unit"
   gem "mocha", :require => false
   gem "factory_girl_rails"
   gem "database_cleaner"
+end
+
+group :development, :test do
+  gem "sqlite3"
 end
 
 group :production do


### PR DESCRIPTION
This commit suppresses these warnings

```
Your Gemfile lists the gem sqlite3 (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```