### PR TITLE
Setup devise for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,43 +12,46 @@
 ##Installation
 
   1. Configuration
-  
+
     Copy config/webistrano_config.rb.sample to config/webistrano_config.rb
     and edit appropriatly. In this configuration file you can set the mail
     settings of Webistrano.
-  
+
+    Copy config/initializers/devise.rb.sample to config/initializers/devise.rb
+    and edit appropriatly.
+
   2. Database
-  
+
     Copy config/database.yml.sample to config/database.yml and edit to
     resemble your setting. You need at least the production database.
     The others are optional entries for development and testing.
-  
+
     Then create the database structure with Rake:
-  
+
     > cd webistrano
 
     > RAILS_ENV=production rake db:migrate
-  
+
   3. Data initialization
 
     > cd webistrano
 
     > RAILS_ENV=production rake db:seed
 
-  4. Start Webistrano  
-  
+  4. Start Webistrano
+
     > cd webistrano
 
     > ruby script/server -d -p 3000 -e production
-  
+
     Webistrano is then available at http://localhost:3000/
-  
+
     The default user is `admin`, the password is `admin!`. Please change the password
     after the first login.
-  
+
 ##Author
   Jonathan Weiss <jw@innerewut.de>
-  
+
 ##License
   Code: BSD, see LICENSE.txt
   Images: Right to use in their provided form in Webistrano installations. No other right granted.

--- a/config/initializers/devise.rb.sample
+++ b/config/initializers/devise.rb.sample
@@ -51,10 +51,10 @@ Devise.setup do |config|
   # ==> Configuration for :confirmable
   # The time you want to give your user to confirm his account. During this time
   # he will be able to access your application without confirming. Default is nil.
-  # When confirm_within is zero, the user won't be able to sign in without confirming. 
-  # You can use this to let your user access some features of your application 
-  # without confirming the account, but blocking it after a certain period 
-  # (ie 2 days). 
+  # When confirm_within is zero, the user won't be able to sign in without confirming.
+  # You can use this to let your user access some features of your application
+  # without confirming the account, but blocking it after a certain period
+  # (ie 2 days).
   # config.confirm_within = 2.days
 
   # ==> Configuration for :rememberable
@@ -113,7 +113,7 @@ Devise.setup do |config|
   # devise role declared in your routes.
   # config.default_scope = :user
 
-  # Configure sign_out behavior. 
+  # Configure sign_out behavior.
   # By default sign_out is scoped (i.e. /users/sign_out affects only :user scope).
   # In case of sign_out_all_scopes set to true any logout action will sign out all active scopes.
   # config.sign_out_all_scopes = false

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,0 +1,45 @@
+require "fileutils"
+
+desc "Run the Continuous Integration tests"
+task :ci do
+  # RAILS_ENV and ENV[] can diverge so force them both to test
+  ENV['RAILS_ENV'] = 'test'
+  RAILS_ENV = 'test'
+  Rake::Task["ci:setup"].invoke
+  Rake::Task["ci:build"].invoke
+  Rake::Task["ci:teardown"].invoke
+end
+
+namespace :ci do
+  task :setup do
+    Rake::Task["tmp:clear"].invoke
+    Rake::Task["log:clear"].invoke
+    Rake::Task["config/database.yml"].invoke
+    Rake::Task["config/initializers/devise.rb"].invoke
+    Rake::Task["db:create"].invoke
+    Rake::Task["db:migrate"].invoke
+  end
+
+  task :build do
+    # if test_suite = ENV['TEST_SUITE']
+    #   Rake::Task["test:#{test_suite}"].invoke
+    # else
+      Rake::Task["test"].invoke
+    # end
+  end
+
+  task :teardown do
+    FileUtils.rm('config/initializers/devise.rb', force: true)
+    FileUtils.rm('config/initializers/devise.rb', force: true)
+  end
+end
+
+desc "Creates initializers/devise.rb for the CI server"
+file 'config/initializers/devise.rb' do
+  FileUtils.cp "test/support/devise.rb", "config/initializers/devise.rb"
+end
+
+desc "Creates database.yml for the CI server"
+file 'config/database.yml' do
+  FileUtils.cp "config/database.yml.sample", "config/database.yml"
+end

--- a/test/support/devise.rb
+++ b/test/support/devise.rb
@@ -1,0 +1,144 @@
+# Use this hook to configure devise mailer, warden hooks and so forth. The first
+# four configuration values can also be set straight in your models.
+Devise.setup do |config|
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in DeviseMailer.
+  config.mailer_sender = "please-change-me@config-initializers-devise.com"
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = "Devise::Mailer"
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating an user. By default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating an user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  config.authentication_keys = [ :login ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Basic Auth is enabled. False by default.
+  # config.http_authenticatable = false
+
+  # Set this to true to use Basic Auth for AJAX requests.  True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication
+  # config.http_authentication_realm = "Application"
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  config.stretches = 10
+
+  # Define which will be the encryption algorithm. Devise also supports encryptors
+  # from others authentication tools as :clearance_sha1, :authlogic_sha512 (then
+  # you should set stretches above to 20 for default behavior) and :restful_authentication_sha1
+  # (then you should set stretches to 10, and copy REST_AUTH_SITE_KEY to pepper)
+  config.encryptor = :bcrypt
+
+  # Setup a pepper to generate the encrypted password.
+  config.pepper = "1847c63d4fb5c12113acf8000cc014a1ae6f683736238d7ed197a0a74a2b5058ba737f945087e9493437a2a837cff8a473fdfbc17986f52ba8bf82f3cbdb9933"
+
+  # ==> Configuration for :confirmable
+  # The time you want to give your user to confirm his account. During this time
+  # he will be able to access your application without confirming. Default is nil.
+  # When confirm_within is zero, the user won't be able to sign in without confirming.
+  # You can use this to let your user access some features of your application
+  # without confirming the account, but blocking it after a certain period
+  # (ie 2 days).
+  # config.confirm_within = 2.days
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  config.remember_for = 2.weeks
+
+  # If true, a valid remember token can be re-used between multiple browsers.
+  # config.remember_across_browsers = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  config.extend_remember_period = true
+
+  # ==> Configuration for :validatable
+  # Range for password length
+  # config.password_length = 6..20
+
+  # Regex to use to validate the email address
+  # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again.
+  # config.timeout_in = 10.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # ==> Configuration for :token_authenticatable
+  # Defines name of the authentication token params key
+  # config.token_authentication_key = :auth_token
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = true
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes.
+  # config.default_scope = :user
+
+  # Configure sign_out behavior.
+  # By default sign_out is scoped (i.e. /users/sign_out affects only :user scope).
+  # In case of sign_out_all_scopes set to true any logout action will sign out all active scopes.
+  # config.sign_out_all_scopes = false
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists. Default is [:html]
+  # config.navigational_formats = [:html, :iphone]
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not (yet) supported by Devise,
+  # you can configure them inside the config.warden block. The example below
+  # allows you to setup OAuth, using http://github.com/roman/warden_oauth
+  #
+  # config.warden do |manager|
+  #   manager.oauth(:twitter) do |twitter|
+  #     twitter.consumer_secret = <YOUR CONSUMER SECRET>
+  #     twitter.consumer_key  = <YOUR CONSUMER KEY>
+  #     twitter.options :site => 'http://twitter.com'
+  #   end
+  #   manager.default_strategies(:scope => :user).unshift :twitter_oauth
+  # end
+
+  config.secret_key = 'secretkey0123456789'
+end


### PR DESCRIPTION
To run tests we should setup `Devise.config.secret_key`.
Writing `config.secret_key` to `config/initializers/devise.rb`
directly is not proper way, because users (not webistrano developers)
use `config/initializers/devise.rb`.

This commit makes webistrano developers to run tests easily by
`bundle exec rake ci`.
